### PR TITLE
Remove dependency on the stringi package

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: nsyllable
-Version: 0.10
+Version: 0.20
 Title: Syllable counter
 Description: Add more description here.
 Authors@R: c( 
@@ -8,8 +8,6 @@ Authors@R: c(
 License: GPL-3
 Depends:
     R (>= 2.10)
-Imports:
-    stringi
 Suggests:
     knitr
 URL: https://github.com/quanteda/nsyllable

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,5 +2,3 @@
 
 S3method(nsyllable,character)
 export(nsyllable)
-importFrom(stringi,stri_count_regex)
-importFrom(stringi,stri_trans_tolower)

--- a/R/nsyllable.R
+++ b/R/nsyllable.R
@@ -47,23 +47,25 @@ nsyllable <- function(x, syllable_dictionary = nsyllable::data_int_syllables,
 }
 
 #' @rdname nsyllable
-#' @importFrom stringi stri_trans_tolower stri_count_regex
 #' @noRd
 #' @export
 nsyllable.character <- function(x, syllable_dictionary = nsyllable::data_int_syllables, 
                                 use.names = FALSE) { 
     # look up syllables
-    result <- syllable_dictionary[stri_trans_tolower(x)]
+    result <- syllable_dictionary[tolower(x)]
+    # count vowels if the word did not match the syllable dictionary
+    result[is.na(result)] <-
+        sapply(gregexpr("[aeiouy]+", x[is.na(result)]), 
+               function(y) length(attr(y, "match.length")))
+    # so we don't words with no vowels as having syllables
+    result[which(result == 0)] <- NA
+
     # keep or discard names
     if (use.names) {
         names(result) <- x
     } else {
         result <- unname(result)
     }
-    # count vowels if the word did not match the syllable dictionary
-    result[is.na(result)] <- 
-        stri_count_regex(x[is.na(result)], "[aeiouy]+", case_insensitive = TRUE)
-    # so we don't words with no vowels as having syllables
-    result[which(result == 0)] <- NA
+    
     result
 }


### PR DESCRIPTION
Removes the import of functions from **stringi**. Makes this the simplest package in the world from the standpoint of dependency on non-core packages, since it now has none.

- use base::tolower() instead of stringi::stri_trans_tolower().  This seems ok since the Unicode handling in R 4.x and beyond is much improved.

- use the length of matched for vowels from the first attribute of the return from base::gregexpr() instead of stringi::stri_count_regex().